### PR TITLE
Allow Python 3.8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # Run in all these versions of Python
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.9", "3.8"]
 
     steps:
       # Checkout the latest code from the repo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pymccool"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   { name="Brendon McCool", email="brendonmccool@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "Reusable Python Utilities by McCool"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Some projects are stuck with older versions of python.  This PR brings in support for python 3.8 and 3.9 instead of just 3.10.