### PR TITLE
fix(logger): allow unicode characters

### DIFF
--- a/src/pymccool/logging.py
+++ b/src/pymccool/logging.py
@@ -103,7 +103,8 @@ class Logger:
         debug_file_handler = RotatingFileHandler(
             filename=f'Logs/Debug/{info.app_name}_debug.log',
             maxBytes=1000000,
-            backupCount=100)
+            backupCount=100,
+            encoding='utf-8')
         debug_file_handler.setLevel(logging.DEBUG)
         debug_file_handler.setFormatter(formatter)
 
@@ -111,7 +112,8 @@ class Logger:
         info_file_handler = RotatingFileHandler(
             filename=f'Logs/Info/{info.app_name}_info.log',
             maxBytes=1000000,
-            backupCount=100)
+            backupCount=100,
+            encoding='utf-8')
         info_file_handler.setLevel(logging.INFO)
         info_file_handler.setFormatter(formatter)
 

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -279,3 +279,34 @@ def test_logger_loki_unit():
     assert "Test Error" in logged_lines[5]
 
     logger2.close()
+
+def test_logger_unicode():
+    """
+    Check that the logger can handle unicode characters
+    """
+    # Delete any preexisting logs
+    with open("Logs/Info/test_unicode_info.log", "w", encoding="utf-8") as log_file:
+        log_file.write("")
+
+    string_capture = io.StringIO()
+    with redirect_stdout(string_capture):
+        logger = Logger(app_name="test_unicode")
+        logger.info("┏━┓")
+        logger.info("┃ ┃")
+        logger.info("┗━┛")
+
+    logged_lines = string_capture.getvalue().strip("\n").split("\n")
+    assert len(logged_lines) == 3
+    assert "┏━┓" in logged_lines[0]
+    assert "┃ ┃" in logged_lines[1]
+    assert "┗━┛" in logged_lines[2]
+
+    with open("Logs/Info/test_unicode_info.log", "r", encoding="utf-8") as log_file:
+        log_lines = log_file.read().strip("\n").split("\n")
+        assert len(log_lines) == 3
+        assert "┏━┓" in log_lines[0]
+        assert "┃ ┃" in log_lines[1]
+        assert "┗━┛" in log_lines[2]
+    
+
+    logger.close()


### PR DESCRIPTION

Closes https://github.com/bmccool/pyMcCool/issues/30

<!--
Ensure the PR Title conforms to Semantic Versioning as per https://bitforce.gitbook.io/the-anatomy-of-an-angular-app/conventional-changelog-and-commitizen

This means the final commit must conform to header/body/footer:

<header>
<BLANK LINE>
<body>
<BLANK LINE>
<footer>

With a Squash Merge, this would look like this:
Commit Message: <header>
Optional Extended Desription: <body> <BLANK LINE> <footer>

If this is a breaking change (Breaks backwards compatibility) you MUST including BREAKING CHANGE in the squash merge for this PR.  E.g.

------------------------------------------------------------
feat(renderer): New renderer with 600% performance increase!

BREAKING CHANGE: Totally new API.

Close #1234.
------------------------------------------------------------

Titles should be of the following form (scope is optional)

<type>(<scope>): <short summary>
  │       │             │
  │       │             └─⫸ Summary in present tense. Not capitalized. No period at the end.
  │       │
  │       └─⫸ Commit Scope: animations|bazel|benchpress|common|compiler|compiler-cli|core|
  │                          elements|forms|http|language-service|localize|platform-browser|
  │                          platform-browser-dynamic|platform-server|router|service-worker|
  │                          upgrade|zone.js|packaging|changelog|docs-infra|migrations|
  │                          devtools
  │
  └─⫸ Commit Type: build|ci|docs|feat|fix|perf|refactor|test|style|chore|revert

-->